### PR TITLE
Unify Python virtual environment configuration to backend/.venv

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "chat.useAgentsMdFile": true,
     "github.copilot.chat.codeGeneration.useInstructionFiles": true,
-    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.defaultInterpreterPath": "${workspaceFolder}/backend/.venv/bin/python",
     "python.terminal.activateEnvironment": true,
     "chat.agent.maxRequests": 50,
     "chat.tools.terminal.autoApprove": false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ Data models follow FHIR nomenclature:
 ## Definition of Done
 
 - `./scripts/test_gate.sh` passes locally (includes schema hash check).
-- `cd backend && pytest tests/unit/test_architecture_dead_code_guards.py -v` passes.
+- `cd backend && .venv/bin/pytest tests/unit/test_architecture_dead_code_guards.py -v` passes.
 - New infrastructural abstractions (routing wrappers, validators, service helpers) have at least one runtime consumer and one automated test.
 - Architecture and agent contract documentation reflect implemented state (not aspirational state).
 

--- a/docs/plans/2026-02-10-agentic-setup-alignment.md
+++ b/docs/plans/2026-02-10-agentic-setup-alignment.md
@@ -101,7 +101,7 @@ Expected: policy and naming are clearly documented.
 
 **Step 1: Run focused architecture guardrail tests**
 
-Run: `cd backend && pytest tests/unit/test_architecture_dead_code_guards.py -v --tb=short`
+Run: `cd backend && .venv/bin/pytest tests/unit/test_architecture_dead_code_guards.py -v --tb=short`
 Expected: all tests pass; warning-only drift output appears only if mismatches exist.
 
 **Step 2: Run local gate**


### PR DESCRIPTION
## Summary
Standardizes Python virtual environment to eliminate configuration errors between VS Code and development scripts.

## Changes
- VS Code settings updated to use backend/.venv/bin/python
- Created backend/.venv with Python 3.11 and all dependencies  
- Updated all documentation to consistently reference backend/.venv
- Removed outdated references to root .venv

## Verification
- All scripts (test_gate.sh, generate-types.sh) work correctly
- Backend commands from AGENTS.md execute properly
- No regressions in development workflow
- Gate tests pass successfully

## Test Commands
```bash
./scripts/test_gate.sh
python -c "import sys; print(sys.executable)"  # Should point to backend/.venv
```